### PR TITLE
Remove unused FontAwesome and Prism.js CSS

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -1,0 +1,25 @@
+<meta charset="utf-8">
+
+{% include seo.html %}
+
+{% unless site.atom_feed.hide %}
+  <link href="{% if site.atom_feed.path %}{{ site.atom_feed.path }}{% else %}{{ '/feed.xml' | relative_url }}{% endif %}" type="application/atom+xml" rel="alternate" title="{{ site.title }} Feed">
+{% endunless %}
+
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+
+<script>
+  document.documentElement.className = document.documentElement.className.replace(/\bno-js\b/g, '') + ' js ';
+  {% if site.enable_copy_code_button -%}
+    window.enable_copy_code_button = true;
+  {%- endif %}
+</script>
+
+<!-- For all browsers -->
+<link rel="stylesheet" href="{{ '/assets/css/main.css' | relative_url }}">
+
+{% if site.head_scripts %}
+  {% for script in site.head_scripts %}
+    <script src="{{ script | relative_url }}"></script>
+  {% endfor %}
+{% endif %}

--- a/_includes/head/custom.html
+++ b/_includes/head/custom.html
@@ -74,8 +74,3 @@
 <!-- Structured Data for SEO -->
 {% include structured-data.html %}
 
-<!-- Enhanced Syntax Highlighting with Prism.js -->
-<link href="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/themes/prism.min.css" rel="stylesheet" />
-<link href="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/themes/prism-okaidia.min.css" rel="stylesheet" media="(prefers-color-scheme: dark)" />
-<link href="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/plugins/toolbar/prism-toolbar.min.css" rel="stylesheet" />
-<link href="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/plugins/copy-to-clipboard/prism-copy-to-clipboard.min.css" rel="stylesheet" />


### PR DESCRIPTION
## Summary
- Override theme `head.html` to remove FontAwesome CSS (we use inline SVG icons now)
- Remove Prism.js CSS references from `head/custom.html` (syntax highlighting uses Jekyll Rouge)

These unused stylesheets were still being loaded on the live site, adding unnecessary network requests and potentially causing style conflicts.

## Test plan
- [ ] Verify no FontAwesome or Prism.js CSS in page source
- [ ] Verify site renders correctly (icons, code blocks, layout)
- [ ] Check both light and dark mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)