### PR TITLE
Fix page content offset by removing sidebar layout

### DIFF
--- a/_sass/custom.scss
+++ b/_sass/custom.scss
@@ -236,11 +236,17 @@ h1, h2, h3, h4, h5, h6 {
   }
 }
 
-/* Layout overrides - constrain content width */
+/* Layout overrides - constrain content width and remove sidebar layout */
 #main {
   max-width: var(--container-max-width);
   margin: 0 auto;
   padding: 0 var(--spacing-xl);
+}
+
+.page {
+  float: none !important;
+  width: 100% !important;
+  padding-inline-end: 0 !important;
 }
 
 .page__content {
@@ -250,9 +256,16 @@ h1, h2, h3, h4, h5, h6 {
 }
 
 .page__inner-wrap {
+  float: none !important;
   width: 100%;
   margin: 0;
   padding: 0;
+}
+
+.archive {
+  float: none !important;
+  width: 100% !important;
+  padding-inline-end: 0 !important;
 }
 
 /* Homepage container */


### PR DESCRIPTION
## Summary
- Override theme's `.page` and `.archive` CSS that applies `float: inline-end` and `width: calc(100% - 200/300px)` to reserve space for a sidebar
- Since we don't use a sidebar, this was pushing all content to the right side of the page
- Override `.page__inner-wrap` float as well for consistent full-width layout

## Test plan
- [ ] Verify content is centered on homepage, About, and Posts pages
- [ ] Check individual post pages are centered
- [ ] Verify on both desktop and mobile viewports

🤖 Generated with [Claude Code](https://claude.com/claude-code)