### PR TITLE
Redesign Posts page with year/month grouping

### DIFF
--- a/_layouts/posts.html
+++ b/_layouts/posts.html
@@ -1,0 +1,38 @@
+---
+layout: single
+---
+
+<div class="posts-container">
+  <p class="posts-subtitle">Browse all blog posts by year and month</p>
+
+  {% assign postsByYear = site.posts | where_exp: "item", "item.hidden != true" | group_by_exp: 'post', 'post.date | date: "%Y"' %}
+  {% for year in postsByYear %}
+    {% assign yearCount = year.items | size %}
+    <div class="posts-year">
+      <h2 class="posts-year__title">{{ year.name }} <sup class="posts-year__count">{{ yearCount }}</sup></h2>
+
+      {% assign postsByMonth = year.items | group_by_exp: 'post', 'post.date | date: "%B"' %}
+      {% for month in postsByMonth %}
+        {% assign monthCount = month.items | size %}
+        <h3 class="posts-month__title">{{ month.name }} <sup class="posts-month__count">{{ monthCount }}</sup></h3>
+
+        {% for post in month.items %}
+          <article class="posts-entry">
+            <a href="{{ post.url | relative_url }}" class="posts-entry__title-link">{{ post.title }}</a>
+            <div class="posts-entry__meta">
+              {% include icon-calendar.html %}
+              <time datetime="{{ post.date | date_to_xmlschema }}">{{ post.date | date: "%d %b, %Y" }}</time>
+              {% assign words = post.content | number_of_words %}
+              {% assign minutes = words | plus: 199 | divided_by: 200 %}
+              {% if minutes < 1 %}{% assign minutes = 1 %}{% endif %}
+              <span>&bull; {{ minutes }} min read</span>
+            </div>
+            {% if post.excerpt %}
+              <p class="posts-entry__excerpt">{{ post.excerpt | strip_html | truncate: 200 }}</p>
+            {% endif %}
+          </article>
+        {% endfor %}
+      {% endfor %}
+    </div>
+  {% endfor %}
+</div>

--- a/_layouts/posts.html
+++ b/_layouts/posts.html
@@ -4,6 +4,7 @@ layout: single
 
 <div class="posts-container">
   <p class="posts-subtitle">Browse all blog posts by year and month</p>
+  {{ content }}
 
   {% assign postsByYear = site.posts | where_exp: "item", "item.hidden != true" | group_by_exp: 'post', 'post.date | date: "%Y"' %}
   {% for year in postsByYear %}

--- a/_layouts/posts.html
+++ b/_layouts/posts.html
@@ -6,16 +6,16 @@ layout: single
   <p class="posts-subtitle">Browse all blog posts by year and month</p>
   {{ content }}
 
-  {% assign postsByYear = site.posts | where_exp: "item", "item.hidden != true" | group_by_exp: 'post', 'post.date | date: "%Y"' %}
-  {% for year in postsByYear %}
-    {% assign yearCount = year.items | size %}
+  {% assign posts_by_year = site.posts | where_exp: "item", "item.hidden != true" | group_by_exp: 'post', 'post.date | date: "%Y"' %}
+  {% for year in posts_by_year %}
+    {% assign year_count = year.items | size %}
     <div class="posts-year">
-      <h2 class="posts-year__title">{{ year.name }} <sup class="posts-year__count">{{ yearCount }}</sup></h2>
+      <h2 class="posts-year__title">{{ year.name }} <sup class="posts-year__count">{{ year_count }}</sup></h2>
 
-      {% assign postsByMonth = year.items | group_by_exp: 'post', 'post.date | date: "%B"' %}
-      {% for month in postsByMonth %}
-        {% assign monthCount = month.items | size %}
-        <h3 class="posts-month__title">{{ month.name }} <sup class="posts-month__count">{{ monthCount }}</sup></h3>
+      {% assign posts_by_month = year.items | group_by_exp: 'post', 'post.date | date: "%B"' %}
+      {% for month in posts_by_month %}
+        {% assign month_count = month.items | size %}
+        <h3 class="posts-month__title">{{ month.name }} <sup class="posts-month__count">{{ month_count }}</sup></h3>
 
         {% for post in month.items %}
           <article class="posts-entry">

--- a/_layouts/posts.html
+++ b/_layouts/posts.html
@@ -21,7 +21,9 @@ layout: single
           <article class="posts-entry">
             <a href="{{ post.url | relative_url }}" class="posts-entry__title-link">{{ post.title }}</a>
             <div class="posts-entry__meta">
-              {% include icon-calendar.html %}
+              <span aria-hidden="true" class="posts-entry__calendar-icon">
+                {% include icon-calendar.html %}
+              </span>
               <time datetime="{{ post.date | date_to_xmlschema }}">{{ post.date | date: "%d %b, %Y" }}</time>
               {% assign words = post.content | number_of_words %}
               {% assign minutes = words | plus: 199 | divided_by: 200 %}

--- a/_sass/custom.scss
+++ b/_sass/custom.scss
@@ -634,109 +634,83 @@ img {
   flex-shrink: 0;
 }
 
-/* Posts page - taxonomy index (year grid) */
-.taxonomy__index {
-  display: grid;
-  grid-template-columns: repeat(2, 1fr);
-  gap: 0;
-  list-style: none;
-  padding: 0;
-  margin: 0 0 var(--spacing-xl) 0;
-  border: 1px solid var(--border-light);
-  border-radius: var(--border-radius);
-  overflow: hidden;
-
-  li {
-    margin: 0;
-    border-bottom: 1px solid var(--border-light);
-
-    &:nth-child(odd) {
-      border-right: 1px solid var(--border-light);
-    }
-
-    /* Remove bottom border from items in the last row */
-    &:nth-last-child(-n+2) {
-      border-bottom: none;
-    }
-
-    /* When there is an odd number of items, restore the border
-       for the second-to-last item, which is still in the previous row */
-    &:nth-last-child(2):nth-child(even) {
-      border-bottom: 1px solid var(--border-light);
-    }
-  }
-
-  a {
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-    padding: var(--spacing-sm) var(--spacing-md);
-    color: var(--text-primary);
-    text-decoration: none;
-    transition: background-color 0.2s ease;
-
-    &:hover {
-      background: var(--background-light);
-    }
-
-    strong {
-      font-weight: 600;
-    }
-  }
-
-  .taxonomy__count {
-    color: var(--text-secondary);
-    font-size: 0.85rem;
-  }
+/* Posts page */
+.posts-container {
+  padding: var(--spacing-lg) 0;
 }
 
-/* Posts page - year sections */
-.taxonomy__section {
+.posts-subtitle {
+  color: var(--text-secondary);
+  font-size: 1rem;
+  margin: 0 0 var(--spacing-xl) 0;
+}
+
+.posts-year {
   margin-bottom: var(--spacing-xl);
 }
 
-.archive__subtitle {
-  font-size: 1.3rem;
-  font-weight: 600;
+.posts-year__title {
+  font-size: 1.8rem;
+  font-weight: 700;
   color: var(--text-primary);
+  margin: 0;
   padding-bottom: var(--spacing-sm);
-  border-bottom: 1px solid var(--border-light);
-  margin-bottom: var(--spacing-md);
+  border-bottom: 2px solid var(--accent-color);
 }
 
-/* Posts page - individual post items */
-.entries-list {
-  .list__item {
-    padding: var(--spacing-md) 0;
-    border-bottom: 1px solid var(--border-light);
+.posts-year__count {
+  font-size: 0.9rem;
+  font-weight: 400;
+  color: var(--text-secondary);
+}
 
-    &:last-child {
-      border-bottom: none;
-    }
+.posts-month__title {
+  font-size: 1.3rem;
+  font-weight: 700;
+  color: var(--text-primary);
+  margin: var(--spacing-lg) 0 var(--spacing-md) 0;
+}
+
+.posts-month__count {
+  font-size: 0.8rem;
+  font-weight: 400;
+  color: var(--text-secondary);
+}
+
+.posts-entry {
+  margin-bottom: var(--spacing-lg);
+}
+
+.posts-entry__title-link {
+  font-size: 1.15rem;
+  font-weight: 600;
+  color: var(--accent-color) !important;
+  text-decoration: none;
+  line-height: 1.4;
+
+  &:hover {
+    text-decoration: underline;
   }
+}
 
-  .archive__item-title {
-    font-size: 1.1rem;
-    font-weight: 600;
-    margin: 0 0 var(--spacing-sm) 0;
-    line-height: 1.4;
+.posts-entry__meta {
+  display: flex;
+  align-items: center;
+  gap: 0.4em;
+  color: var(--text-secondary);
+  font-size: 0.85rem;
+  margin-top: 0.3em;
 
-    a {
-      color: var(--text-primary);
-      text-decoration: none;
-
-      &:hover {
-        color: var(--accent-color);
-      }
-    }
+  .icon {
+    opacity: 0.7;
   }
+}
 
-  .archive__item-excerpt {
-    color: var(--text-secondary);
-    font-size: 0.9rem;
-    line-height: 1.6;
-    margin: 0;
-  }
+.posts-entry__excerpt {
+  color: var(--text-secondary);
+  font-size: 0.95rem;
+  line-height: 1.6;
+  margin: 0.5em 0 0 0;
 }
 
 /* Responsive design */

--- a/_sass/custom.scss
+++ b/_sass/custom.scss
@@ -684,7 +684,7 @@ img {
 .posts-entry__title-link {
   font-size: 1.15rem;
   font-weight: 600;
-  color: var(--accent-color) !important;
+  color: var(--accent-color);
   text-decoration: none;
   line-height: 1.4;
 


### PR DESCRIPTION
## Summary
- Replace year grid layout with chronological year → month → post grouping (inspired by steipete.me)
- Year headers with accent-colored underline and post count superscript
- Month headers with post count superscript
- Post entries with accent-colored title links, calendar icon, date, reading time, and excerpts

## Test plan
- [ ] Verify Posts page renders with year/month grouping
- [ ] Check post counts are correct for each year and month
- [ ] Verify calendar icons and reading time display
- [ ] Test in both light and dark mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)