### PR TITLE
Fix masthead spacing and swap nav order

### DIFF
--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -1,6 +1,6 @@
 # main links
 main:
-  - title: "About"
-    url: /about/
   - title: "Posts"
     url: /posts/
+  - title: "About"
+    url: /about/

--- a/_sass/custom.scss
+++ b/_sass/custom.scss
@@ -54,9 +54,10 @@ h1, h2, h3, h4, h5, h6 {
 }
 
 .masthead__nav {
-  display: flex;
+  display: flex !important;
   align-items: center;
   justify-content: space-between;
+  width: 100%;
 }
 
 .site-title {
@@ -68,9 +69,19 @@ h1, h2, h3, h4, h5, h6 {
   color: var(--text-primary) !important;
   text-decoration: none;
   letter-spacing: -0.01em;
+  margin-right: auto;
+  flex-shrink: 0;
 
   &:hover {
     color: var(--text-secondary) !important;
+  }
+}
+
+/* Override theme greedy-nav styles */
+.greedy-nav {
+  background: transparent !important;
+  .visible-links {
+    flex: initial !important;
   }
 }
 


### PR DESCRIPTION
## Summary
- Swap navigation order: Posts first, About second
- Fix site title text running directly into nav links by adding `margin-right: auto` to push nav right
- Override theme's `.greedy-nav` styles that interfered with the custom masthead layout

## Test plan
- [ ] Verify "Scott Densmore" has proper spacing from nav links
- [ ] Verify nav order is Posts, About, then social icons
- [ ] Check on mobile viewport

🤖 Generated with [Claude Code](https://claude.com/claude-code)