### PR TITLE
Reduce meta font size and remove Posts page title

### DIFF
--- a/_pages/posts.md
+++ b/_pages/posts.md
@@ -1,8 +1,6 @@
 ---
-title: "All Posts"
+title: ""
 permalink: /posts/
 layout: posts
 author_profile: false
 ---
-
-This page contains an archive of all posts on this blog, organized by date.

--- a/_sass/custom.scss
+++ b/_sass/custom.scss
@@ -323,7 +323,7 @@ h1, h2, h3, h4, h5, h6 {
   align-items: center;
   gap: var(--spacing-md);
   color: var(--text-secondary);
-  font-size: 0.85rem;
+  font-size: 0.75rem;
   margin-bottom: var(--spacing-sm);
 }
 
@@ -616,7 +616,7 @@ img {
   gap: var(--spacing-sm);
   margin-bottom: var(--spacing-lg);
   color: var(--text-secondary);
-  font-size: 0.85rem;
+  font-size: 0.75rem;
   flex-wrap: wrap;
 
   time {
@@ -709,7 +709,7 @@ img {
   align-items: center;
   gap: 0.4em;
   color: var(--text-secondary);
-  font-size: 0.85rem;
+  font-size: 0.75rem;
   margin-top: 0.3em;
 
   .icon {


### PR DESCRIPTION
## Summary
- Reduce date/reading time font size from 0.85rem to 0.75rem across homepage, post pages, and posts archive
- Remove "All Posts" heading and description text from the Posts page

## Test plan
- [ ] Verify smaller meta text on homepage, individual posts, and posts archive
- [ ] Verify Posts page no longer shows "All Posts" heading

🤖 Generated with [Claude Code](https://claude.com/claude-code)