### PR TITLE
ci: bump Pages workflow actions off deprecated Node 20

### DIFF
--- a/.github/workflows/jekyll.yml
+++ b/.github/workflows/jekyll.yml
@@ -32,16 +32,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
       - name: Setup Ruby
-        # https://github.com/ruby/setup-ruby/releases/tag/v1.207.0
-        uses: ruby/setup-ruby@09a7688d3b55cf0e976497ff046b70949eeaccfd
+        # https://github.com/ruby/setup-ruby/releases/tag/v1.321.0
+        uses: ruby/setup-ruby@95ef2b042f9d7a56d8268cba8559e2842e2ad01b
         with:
           bundler-cache: true # runs 'bundle install' and caches installed gems automatically
           cache-version: 0 # Increment this number if you need to re-download cached gems
       - name: Setup Pages
         id: pages
-        uses: actions/configure-pages@v5
+        uses: actions/configure-pages@v6
       - name: Build with Jekyll
         # Outputs to the './_site' directory by default
         run: bundle exec jekyll build --baseurl "${{ steps.pages.outputs.base_path }}"
@@ -49,7 +49,7 @@ jobs:
           JEKYLL_ENV: production
       - name: Upload artifact
         # Automatically uploads an artifact from the './_site' directory by default
-        uses: actions/upload-pages-artifact@v4
+        uses: actions/upload-pages-artifact@v5
 
   # Deployment job
   deploy:
@@ -61,4 +61,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5


### PR DESCRIPTION
## Summary

Bumps the GitHub Pages deploy workflow (`.github/workflows/jekyll.yml`) actions to their latest majors, all of which run on **Node 24**. This clears the "Node.js 20 is deprecated" annotations seen on the last deploy.

| Action | Before | After |
|---|---|---|
| `actions/checkout` | v6 | v7 |
| `ruby/setup-ruby` | v1.207.0 (`09a7688`) | v1.321.0 (`95ef2b0`, SHA-pinned) |
| `actions/configure-pages` | v5 | v6 |
| `actions/upload-pages-artifact` | v4 | v5 |
| `actions/deploy-pages` | v4 | v5 |

`ruby/setup-ruby` stays SHA-pinned (third-party action) with the release comment updated; the first-party `actions/*` stay on version tags, matching the existing convention.

## Test plan
- Workflow YAML validates (`YAML.load_file`).
- The workflow only runs on push to `main`, so the real check is the deploy that runs after merge — expect it green with no Node 20 annotations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
