### PR TITLE
chore: gitignore local coding-agent tool state

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,11 @@ vendor/
 *.log
 
 .env
+
+# Local coding-agent tool state (not shared)
+.codex/
+.cursor/
+.entire/
+.github/hooks/
+.claude/launch.json
+.claude/settings.local.json


### PR DESCRIPTION
## Summary

Housekeeping: ignore local, per-user coding-agent tool state so it stops showing as untracked changes and can't be accidentally committed. Prerequisite for clean security scans (a dirty tree blocks patch generation).

Adds to `.gitignore`: `.codex/`, `.cursor/`, `.entire/`, `.github/hooks/`, `.claude/launch.json`, `.claude/settings.local.json`.

None of these are shared project files — they're local editor/agent session state (Codex, Cursor, the Entire CLI which regenerates `.entire/` every session, and per-user Claude settings).

## Test plan
- No site impact — `.gitignore` only. Jekyll build unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
