### PR TITLE
security: fix command injection in update-last-modified.rb

### DIFF
--- a/_scripts/update-last-modified.rb
+++ b/_scripts/update-last-modified.rb
@@ -47,7 +47,7 @@ staged_files.each do |file_path|
     File.write(file_path, new_content)
 
     # Stage the changes so they are included in the commit
-    `git add #{file_path}`
+    system('git', 'add', '--', file_path)
 
     puts "  - Updated #{file_path}"
   rescue Psych::SyntaxError => e


### PR DESCRIPTION
## Summary

Fixes a command-injection sink (CWE-78) in `_scripts/update-last-modified.rb`. Staged post filenames from `git diff --cached --name-only` were interpolated **unquoted** into a backtick shell command:

```ruby
`git add #{file_path}`
```

Git doesn't shell-escape filenames, so a staged post named e.g. `_posts/x$(cmd).md` would execute `cmd` when the script runs as the intended pre-commit hook.

The fix uses the shell-free array form:

```ruby
system('git', 'add', '--', file_path)
```

git is invoked directly (no `/bin/sh`), so the path is a single literal argument; the `--` also blocks option injection. Behaviour is unchanged — the modified post is still re-staged.

Found by a Claude Security scan (medium effort, verified 3/3), patch verified by a panel of agents. The verifier's harness reproduced the injection with the old code and confirmed the array form neutralizes it.

## Test plan
- No project test suite exists for these scripts (Jekyll blog). Verified by review + an ad-hoc harness: old backtick form executed an injected marker; new array form staged the same malicious filename literally with no execution, and the `--` guard staged a `--evil.md` path rather than treating it as a git option.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
