### PR TITLE
chore: enable Entire for the codebase

### DIFF
--- a/.entire/.gitignore
+++ b/.entire/.gitignore
@@ -1,0 +1,5 @@
+tmp/
+settings.local.json
+metadata/
+logs/
+redactors/local/

--- a/.entire/settings.json
+++ b/.entire/settings.json
@@ -1,0 +1,4 @@
+{
+  "enabled": true,
+  "telemetry": true
+}

--- a/.github/hooks/entire.json
+++ b/.github/hooks/entire.json
@@ -1,0 +1,61 @@
+{
+  "hooks": {
+    "agentStop": [
+      {
+        "type": "command",
+        "bash": "sh -c 'if ! command -v entire >/dev/null 2>&1; then exit 0; fi; exec entire hooks copilot-cli agent-stop'",
+        "comment": "Entire CLI"
+      }
+    ],
+    "errorOccurred": [
+      {
+        "type": "command",
+        "bash": "sh -c 'if ! command -v entire >/dev/null 2>&1; then exit 0; fi; exec entire hooks copilot-cli error-occurred'",
+        "comment": "Entire CLI"
+      }
+    ],
+    "postToolUse": [
+      {
+        "type": "command",
+        "bash": "sh -c 'if ! command -v entire >/dev/null 2>&1; then exit 0; fi; exec entire hooks copilot-cli post-tool-use'",
+        "comment": "Entire CLI"
+      }
+    ],
+    "preToolUse": [
+      {
+        "type": "command",
+        "bash": "sh -c 'if ! command -v entire >/dev/null 2>&1; then exit 0; fi; exec entire hooks copilot-cli pre-tool-use'",
+        "comment": "Entire CLI"
+      }
+    ],
+    "sessionEnd": [
+      {
+        "type": "command",
+        "bash": "sh -c 'if ! command -v entire >/dev/null 2>&1; then exit 0; fi; exec entire hooks copilot-cli session-end'",
+        "comment": "Entire CLI"
+      }
+    ],
+    "sessionStart": [
+      {
+        "type": "command",
+        "bash": "sh -c 'if ! command -v entire >/dev/null 2>&1; then exit 0; fi; exec entire hooks copilot-cli session-start'",
+        "comment": "Entire CLI"
+      }
+    ],
+    "subagentStop": [
+      {
+        "type": "command",
+        "bash": "sh -c 'if ! command -v entire >/dev/null 2>&1; then exit 0; fi; exec entire hooks copilot-cli subagent-stop'",
+        "comment": "Entire CLI"
+      }
+    ],
+    "userPromptSubmitted": [
+      {
+        "type": "command",
+        "bash": "sh -c 'if ! command -v entire >/dev/null 2>&1; then exit 0; fi; exec entire hooks copilot-cli user-prompt-submitted'",
+        "comment": "Entire CLI"
+      }
+    ]
+  },
+  "version": 1
+}


### PR DESCRIPTION
## Summary

Enables the **Entire CLI** integration for the repository by tracking its config, so it's shared with anyone who clones the repo (reverses the earlier decision to gitignore it — #63, now closed).

Tracks three files:
- `.entire/settings.json` — `{ enabled: true, telemetry: true }`
- `.entire/.gitignore` — Entire's own ignore rules
- `.github/hooks/entire.json` — Entire hook wiring, each command guarded by `command -v entire` (no-ops if Entire isn't installed)

## Safety

This repo is public, but no session data is exposed. Entire's own `.entire/.gitignore` excludes the sensitive/transient paths, so they are **never committed**:

```
tmp/
settings.local.json
metadata/          # session transcripts (full.jsonl) — stay local
logs/
redactors/local/
```

Confirmed via `git add -n`: only the three config files above are tracked; `metadata/`, `logs/`, and `tmp/` are not.

## Test plan
- No site impact (Jekyll build untouched). The hooks are guarded and inert when `entire` isn't on PATH.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
